### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/vanitoo/pythonProject-OpenCV-PDF/security/code-scanning/8](https://github.com/vanitoo/pythonProject-OpenCV-PDF/security/code-scanning/8)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow does not perform any write operations, we will set `contents: read` as the permission. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended modifications.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
